### PR TITLE
build: dockerize client

### DIFF
--- a/client/Dockerfile
+++ b/client/Dockerfile
@@ -8,4 +8,5 @@ COPY ./src/ ./src/
 RUN bun run build
 
 FROM nginx:mainline-alpine-slim
+COPY ./nginx.conf /etc/nginx/conf.d/default.conf
 COPY --from=builder /app/dist /usr/share/nginx/html

--- a/client/nginx.conf
+++ b/client/nginx.conf
@@ -1,0 +1,17 @@
+server {
+    listen 80;
+    server_name localhost;
+    
+    location / {
+        root /usr/share/nginx/html;
+        index index.html index.htm;
+        try_files $uri $uri/ /index.html;
+    }
+    
+    # Proxy api requests to our api-gateway
+    location /api/ {
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_pass http://api-gateway:8080/api/;
+    }
+} 

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,5 +1,3 @@
-version: "3.8"
-
 services:
   eureka:
     build:


### PR DESCRIPTION
As we need to dockerize everything — this PR includes the Dockerfile for client and also integrates it into our docker-compose.

Now it's one command to spin everything up.